### PR TITLE
bug fix: do not call ackMessage when autoAck is true

### DIFF
--- a/src/main/java/com/aweber/flume/source/rabbitmq/Consumer.java
+++ b/src/main/java/com/aweber/flume/source/rabbitmq/Consumer.java
@@ -176,7 +176,7 @@ public class Consumer implements Runnable {
                 continue;
             }
             sourceCounter.incrementEventAcceptedCount();
-            ackMessage(getDeliveryTag(delivery));
+            if(!autoAck) ackMessage(getDeliveryTag(delivery));
         }
 
         // Tell RabbitMQ that the consumer is stopping


### PR DESCRIPTION
Hi,
the code calls method ackMessage() even when the autoack is set to true. that results in channelalreadyclosed exception. it should be calling channel.basicAck only when autoack is false.
