### PR TITLE
feat: Support for custom headers.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.aweber</groupId>
   <artifactId>rabbitmq-flume-plugin</artifactId>
-  <version>1.0.3</version>
+  <version>1.0.3-customheaders-0.1</version>
   <packaging>jar</packaging>
 
   <name>rabbitmq-flume-plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.aweber</groupId>
   <artifactId>rabbitmq-flume-plugin</artifactId>
-  <version>1.0.3</version>
+  <version>1.0.3-customheaders-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>rabbitmq-flume-plugin</name>

--- a/src/main/java/com/aweber/flume/source/rabbitmq/Consumer.java
+++ b/src/main/java/com/aweber/flume/source/rabbitmq/Consumer.java
@@ -176,7 +176,9 @@ public class Consumer implements Runnable {
                 continue;
             }
             sourceCounter.incrementEventAcceptedCount();
-            if(!autoAck) ackMessage(getDeliveryTag(delivery));
+            if (!autoAck) {
+                ackMessage(getDeliveryTag(delivery));
+            }
         }
 
         // Tell RabbitMQ that the consumer is stopping
@@ -291,6 +293,14 @@ public class Consumer implements Runnable {
         }
         if (userId != null && !userId.isEmpty()) {
             headers.put("user-id", userId);
+        }
+
+        Map<String, Object> userHeaders = props.getHeaders();
+
+        if (userHeaders != null && userHeaders.size() > 0) {
+            for (String key : userHeaders.keySet()) {
+                headers.put(key, userHeaders.get(key).toString());
+            }
         }
 
         return headers;

--- a/src/main/java/com/aweber/flume/source/rabbitmq/Consumer.java
+++ b/src/main/java/com/aweber/flume/source/rabbitmq/Consumer.java
@@ -176,7 +176,9 @@ public class Consumer implements Runnable {
                 continue;
             }
             sourceCounter.incrementEventAcceptedCount();
-            if(!autoAck) ackMessage(getDeliveryTag(delivery));
+            if (!autoAck) {
+                ackMessage(getDeliveryTag(delivery));
+            }
         }
 
         // Tell RabbitMQ that the consumer is stopping
@@ -291,6 +293,20 @@ public class Consumer implements Runnable {
         }
         if (userId != null && !userId.isEmpty()) {
             headers.put("user-id", userId);
+        }
+
+        Map<String, Object> userHeaders = props.getHeaders();
+
+        if (userHeaders != null && userHeaders.size() > 0) {
+            for (String key : userHeaders.keySet()) {
+                Object value = userHeaders.get(key);
+                if (value != null) {
+                    headers.put(key, userHeaders.get(key).toString());
+                } else {
+                    // Keep the header just in case has to be used as a flag.
+                    headers.put(key, "");                    
+                }
+            }
         }
 
         return headers;


### PR DESCRIPTION
RabbitMQ allows to include custom headers in messages besides the AMQP headers.

Custom headers are included as a map in AMQP message headers. This change just goes across the map and adds each custom property to the list of headers.
