### PR TITLE
auto bind queues if exchange specified for source

### DIFF
--- a/src/main/java/com/aweber/flume/source/rabbitmq/Consumer.java
+++ b/src/main/java/com/aweber/flume/source/rabbitmq/Consumer.java
@@ -33,6 +33,7 @@ public class Consumer implements Runnable {
     private static final String COUNTER_ACK = "rabbitmq.ack";
     private static final String COUNTER_EXCEPTION = "rabbitmq.exception";
     private static final String COUNTER_REJECT = "rabbitmq.reject";
+    private static final String DEFAULT_ROUTING_KEY = "";
 
     private Connection connection;
     private Channel channel;
@@ -47,6 +48,7 @@ public class Consumer implements Runnable {
     private String username;
     private String password;
     private String queue;
+    private String exchange;
     private boolean autoAck = false;
     private boolean requeuing = false;
     private int prefetchCount = 0;
@@ -126,6 +128,11 @@ public class Consumer implements Runnable {
         return this;
     }
 
+    public Consumer setExchange(String exchange) {
+        this.exchange = exchange;
+        return this;
+    }
+
     @Override
     public void run() {
         DefaultConsumer consumer;
@@ -146,6 +153,11 @@ public class Consumer implements Runnable {
         // Open the channel
         try {
             channel = connection.createChannel();
+            if (null != exchange) {
+                channel.exchangeDeclare(exchange, "direct", true);
+                String queueName = channel.queueDeclare(queue, true, false, false, null).getQueue();
+                channel.queueBind(queueName, exchange, DEFAULT_ROUTING_KEY);
+            }
         } catch (IOException ex) {
             logger.error("Error creating RabbitMQ channel: {}", ex);
             return;

--- a/src/main/java/com/aweber/flume/source/rabbitmq/RabbitMQSource.java
+++ b/src/main/java/com/aweber/flume/source/rabbitmq/RabbitMQSource.java
@@ -28,6 +28,7 @@ public class RabbitMQSource extends AbstractSource implements Configurable, Even
     private static final String VHOST_KEY = "virtual-host";
     private static final String USER_KEY = "username";
     private static final String PASSWORD_KEY = "password";
+    private static final String EXCHANGE_KEY = "exchange";
     private static final String QUEUE_KEY = "queue";
     private static final String AUTOACK_KEY = "auto-ack";
     private static final String PREFETCH_COUNT_KEY = "prefetch-count";
@@ -44,6 +45,7 @@ public class RabbitMQSource extends AbstractSource implements Configurable, Even
     private String username;
     private String password;
     private String queue;
+    private String exchange;
     private boolean autoAck = false;
     private boolean requeuing = false;
     private int prefetchCount = 0;
@@ -76,6 +78,7 @@ public class RabbitMQSource extends AbstractSource implements Configurable, Even
         username = context.getString(USER_KEY, ConnectionFactory.DEFAULT_USER);
         password = context.getString(PASSWORD_KEY, ConnectionFactory.DEFAULT_PASS);
         queue = context.getString(QUEUE_KEY, null);
+        exchange = context.getString(EXCHANGE_KEY, null);
         autoAck = context.getBoolean(AUTOACK_KEY, false);
         requeuing = context.getBoolean(REQUEUING, false);
         prefetchCount = context.getInteger(PREFETCH_COUNT_KEY, 0);
@@ -111,6 +114,9 @@ public class RabbitMQSource extends AbstractSource implements Configurable, Even
                     .setChannelProcessor(getChannelProcessor())
                     .setSourceCounter(sourceCounter)
                     .setCounterGroup(counterGroup);
+            if (null != exchange) {
+                consumer.setExchange(exchange);
+            }
             Thread thread = new Thread(consumer);
             thread.setName("RabbitMQ Consumer #" + String.valueOf(i));
             thread.start();


### PR DESCRIPTION
This PR adds the possibility to specify the exchange name in the `source` and as side effect the Consumer will declare the `queue` and bind it to the exchange.

Fix #10 
